### PR TITLE
bin/client.js: make shebang cross-platform

### DIFF
--- a/bin/client.js
+++ b/bin/client.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var Client = require('../lib/lc-client.js'),
     path = require('path'),


### PR DESCRIPTION
Installing Node.js via [Homebrew](https://brew.sh/) on macOS does not create a symlink at `/usr/bin/node`. AFAIK using the `env` utility is best practice.